### PR TITLE
Fix length for 'Month' / 'Year' and make it more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Interpolate
 ===============================================================================
 
-[![PyPI - Version](https://img.shields.io/pypi/v/beancount_interpolate)](https://pypi.org/project/packages/beancount_interpolate/)
+[![PyPI - Version](https://img.shields.io/pypi/v/beancount-interpolate)](https://pypi.org/project/beancount-interpolate/)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/beancount_interpolate)
 ![PyPI - Wheel](https://img.shields.io/pypi/wheel/beancount_interpolate)
 ![PyPI - License](https://img.shields.io/pypi/l/beancount_interpolate)

--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -138,10 +138,8 @@ def distribute_over_period(params, default_date, total_value, config):
             dates.append(begin_date + i * step)
         i += 1
         if(begin_date + i * step > datetime.date.today()):
-            # If today is reached before begin_date + duration is reached,
-            # add the remaining of total_value to the last amount
-            if sum(amounts) != total_value:
-                amounts[-1] += total_value - sum(amounts)
+            # TODO: If today is reached before begin_date + duration is reached,
+            # the accumulated amounts do not sum up to the original amount
             break
 
     return (dates, amounts)

--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -70,26 +70,30 @@ def parse_mark(mark, default_date, config):
 
     try:
         parts = re.findall(RE_PARSING, mark)[0]
-        if parts[1] and parts[2]:
-            day = max(1, int(parts[3]) if parts[3] != '' else 1)
-            begin_date = datetime.date(int(parts[1]), int(parts[2]), day)
+        if parts[2] and parts[3]:
+            day = max(1, int(parts[4]) if parts[4] != '' else 1)
+            begin_date = datetime.date(int(parts[2]), int(parts[3]), day)
         else:
             begin_date = default_date
 
-        if parts[0]:
-            duration = parse_length(parts[0])
+        duration_multiplier = int(parts[0]) if parts[0] != '' else 1
+        if parts[1]:
+            duration = parse_length(parts[1])
         else:
             duration = parse_length(config['default_duration'])
+        duration *= duration_multiplier
             
         try:
             begin_date + duration
         except OverflowError:
             duration = relativedelta(days=(datetime.datetime(datetime.MAXYEAR, 12, 31).date() - begin_date).days)
 
-        if parts[4]:
-            step = parse_length(parts[4])
+        step_multiplier = int(parts[5]) if parts[5] != '' else 1
+        if parts[6]:
+            step = parse_length(parts[6])
         else:
             step = parse_length(config['default_step'])
+        step *= step_multiplier
 
     except Exception as e:
         # TODO: Error handling
@@ -104,7 +108,7 @@ def parse_mark(mark, default_date, config):
 
 # Infer Duration, start and steps. Spacing optinonal. Format: [123|KEYWORD] [@ YYYY-MM[-DD]] [/ step]
 # 0. max duration, 1. year, 2. month, 3. day, 4. min step
-RE_PARSING = re.compile(r"^\s*?([^-/\s]+)?\s*?(?:@\s*?([0-9]{4})-([0-9]{2})(?:-([0-9]{2}))?)?\s*?(?:\/\s*?([^-/\s]+)?\s*?)?$")
+RE_PARSING = re.compile(r"^\s*([0-9]+)?\s*?([^-/\s]+)?\s*?(?:@\s*?([0-9]{4})-([0-9]{2})(?:-([0-9]{2}))?)?\s*?(?:\/\s*?([0-9]+)?\s*([^-/\s]+)?\s*?)?$")
 def distribute_over_period(params, default_date, total_value, config):
     """
     Distribute value over points in time.

--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -138,8 +138,10 @@ def distribute_over_period(params, default_date, total_value, config):
             dates.append(begin_date + i * step)
         i += 1
         if(begin_date + i * step > datetime.date.today()):
-            # TODO: If today is reached before begin_date + duration is reached,
-            # the accumulated amounts do not sum up to the original amount
+            # If today is reached before begin_date + duration is reached,
+            # add the remaining of total_value to the last amount
+            if sum(amounts) != total_value:
+                amounts[-1] += total_value - sum(amounts)
             break
 
     return (dates, amounts)

--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -129,7 +129,7 @@ def distribute_over_period(params, default_date, total_value, config):
     accumulated_remainder = D(str(0))
 
     i = 0
-    while begin_date + i * step < begin_date + duration and begin_date + i * step <= datetime.date.today():
+    while (begin_date + i * step) < (begin_date + duration) and (begin_date + i * step) <= datetime.date.today():
         accumulated_remainder += total_value / period
         if(abs(round_to(accumulated_remainder)) >= abs(round_to(config['min_value']))):
             amount = D(str(round_to(accumulated_remainder)))

--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -143,8 +143,6 @@ def distribute_over_period(params, default_date, total_value, config):
             dates.append(begin_date + i * step)
         i += 1
         if(begin_date + i * step > datetime.date.today()):
-            # TODO: If today is reached before begin_date + duration is reached,
-            # the accumulated amounts do not sum up to the original amount
             break
 
     return (dates, amounts)

--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -71,7 +71,8 @@ def parse_mark(mark, default_date, config):
     try:
         parts = re.findall(RE_PARSING, mark)[0]
         if parts[1] and parts[2]:
-            begin_date = datetime.date(int(parts[1]), int(parts[2]), int(parts[3]) or 1)
+            day = max(1, int(parts[3]) if parts[3] != '' else 1)
+            begin_date = datetime.date(int(parts[1]), int(parts[2]), day)
         else:
             begin_date = default_date
 

--- a/beancount_interpolate/recur.py
+++ b/beancount_interpolate/recur.py
@@ -1,8 +1,6 @@
 __author__ = 'Akuukis <akuukis@kalvis.lv'
 import datetime
-import math
 
-from beancount.core.amount import Amount
 from beancount.core.data import filter_txns
 from beancount.core.number import D
 
@@ -10,13 +8,14 @@ from .common import extract_mark_tx
 from .common import new_whole_entries
 from .common import read_config
 from .common import parse_mark
+from .common import get_number_of_txn
 
 __plugins__ = ['recur']
 
 
 def dublicate_over_period(params, default_date, value, config):
     begin_date, duration, step = parse_mark(params, default_date, config)
-    period = math.floor( duration / step )
+    period = get_number_of_txn(begin_date, duration, step, config['max_new_tx'])
 
     if(period > config['max_new_tx']):
         period = config['max_new_tx']
@@ -24,11 +23,11 @@ def dublicate_over_period(params, default_date, value, config):
 
     dates = []
     amounts = []
-    date = begin_date
-    while date < begin_date + datetime.timedelta(days=duration) and date <= datetime.date.today():
-        amounts.append( D(str(value)) )
-        dates.append(date)
-        date = date + datetime.timedelta(days=step)
+    i = 0
+    while begin_date + i * step < begin_date + duration and begin_date + i * step <= datetime.date.today():
+        amounts.append(D(str(value)))
+        dates.append(begin_date + i * step)
+        i += 1
 
     return (dates, amounts)
 

--- a/beancount_interpolate/recur.py
+++ b/beancount_interpolate/recur.py
@@ -24,7 +24,7 @@ def dublicate_over_period(params, default_date, value, config):
     dates = []
     amounts = []
     i = 0
-    while begin_date + i * step < begin_date + duration and begin_date + i * step <= datetime.date.today():
+    while (begin_date + i * step) < (begin_date + duration) and (begin_date + i * step) <= datetime.date.today():
         amounts.append(D(str(value)))
         dates.append(begin_date + i * step)
         i += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 beancount
 beancount_plugin_utils
 pytest-bdd
+pytest-cov
 twine


### PR DESCRIPTION
Hello Akuukis,

I like your plugin because it helps me to spread yearly expenses. However the step sizes 'Month' and 'Year' regularly produced too many postings, leading to a total amount larger then the original. This was due to months not having an equal number of days.

In this PR I fixed that by defining `duration` and `step` as `dateutil.relativedelta.relativedelta` instances. This results in the expected behavior for the 'Month' step size. With this, transactions like these:

```
2022-01-01 * "Payee" "Narration"
  spread: "Year @ 2021-01-31 / Month"
  Expenses:SomeYearlyExpense    1,200.00 USD
  Assets:Checking    -1,200.00 USD
```

result in spread transactions of "100.00 USD" on the "2021-01-31", "2021-02-28", "2021-03-31" ...
Thus replicating "end of january" in february. Similar things apply for the "Year" length if there is a leap year.

Another problem I noticed was, that when "today" is closer to `begin_date` than `begin_date + duration`, the total amount of all generated transactions does not sum up to the original one. I fixed that by adding the remaining of `total_value` to the last generated transaction.
EDIT: My bad, the amounts are already tracked on other accounts. I reverted the commit introducing this change.

EDIT:
I also found an error where for dates without a day (e.g. "2022-01") the parsing of the `begin_date` results in a `ValueError` as `""` can't be converted to an int.
Additionally I made the specification for duration and step more flexible. You can now specify transactions like

```
2022-01-01 * "Payee" "Narration"
  spread: "8 Month @ 2021-01-31 / 2 Month"
  Expenses:SomeYearlyExpense    1,200.00 USD
  Assets:Checking    -1,200.00 USD
```
The same thing applies to all other previously possible step and duration values as long as the multiplicative factor is an integer.

Lastly I added `pytest-cov` to `requirements.txt` as it is required for running `make test` and updated the link in the shield to the PyPi package.

All tests are passing for me. Let me know if you have any concerns regarding the changes.

P.S.: May I suggest adding some code formatter like black e.g.? When using flake8 I am getting a lot of linting errors on the current code basis and it is not that easy to read. Additionally it could be wise to add some type hinting to all the methods and include mypy in the test suite. If you are open to it let me know and I can throw together another PR.