### PR TITLE
feat: handle various month and year durations

### DIFF
--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -88,6 +88,11 @@ def parse_mark(mark, default_date, config):
         else:
             duration = parse_length(config['default_duration'])
 
+        try:
+            begin_date + duration
+        except OverflowError:
+            duration = relativedelta(days=(datetime.datetime(datetime.MAXYEAR, 12, 31).date() - begin_date).days)
+
         if parts[4]:
             step = parse_length(parts[4])
         else:
@@ -161,14 +166,17 @@ def parse_length(int_or_string):
         pass
 
     try:
+        max_days = (
+            datetime.datetime(datetime.MAXYEAR, 12, 31).date() - datetime.datetime(datetime.MINYEAR, 1, 1).date()
+        ).days
         dictionary = {
             'day': relativedelta(days=+1),
             'week': relativedelta(weeks=+1),
-            'month': relativedelta(months=+1),  # TODO.
-            'year': relativedelta(years=+1),  # TODO.
-            'inf': relativedelta(days=+(365000000)),
-            'infinite': relativedelta(days=+(365000000)),
-            'max': relativedelta(days=+(365000000))
+            'month': relativedelta(months=+1),
+            'year': relativedelta(years=+1),
+            'inf': relativedelta(days=+max_days),
+            'infinite': relativedelta(days=+max_days),
+            'max': relativedelta(days=+max_days)
         }
         return dictionary[int_or_string.lower()]
     except:

--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -161,7 +161,7 @@ def parse_length(int_or_string):
         A integer.
     """
     try:
-        return int(int_or_string)
+        return relativedelta(days=+int(int_or_string))
     except:
         pass
 

--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -1,5 +1,5 @@
 import datetime
-import math
+from dateutil.relativedelta import relativedelta
 import re
 from beancount.core.number import D
 from beancount.core.amount import Amount, mul
@@ -24,6 +24,24 @@ def extract_mark_posting(posting, config):
         if hasattr(posting, 'meta') and posting.meta and alias in posting.meta:
             return posting.meta[alias]
     return False
+
+
+def get_number_of_txn(begin_date, duration, step, max_txn=float('inf')):
+    """
+    Computes the number of transactions within a given interval and step length.
+
+    Note: As the current implementation is a bit costly with a very large duration
+    and a small step size there is a `max_txn` parameter which can be set.
+    This is meant to be used with the config `max_new_txn`.
+    Upon exceeding `max_txn` the function returns `max_txn + 1`.
+    """
+    n_txn = 0
+    end_date = begin_date + duration
+    while begin_date + n_txn * step < end_date:
+        n_txn += 1
+        if n_txn > max_txn:
+            break
+    return n_txn
 
 
 def extract_mark_tx(tx, config):
@@ -103,7 +121,7 @@ def distribute_over_period(params, default_date, total_value, config):
     """
 
     begin_date, duration, step = parse_mark(params, default_date, config)
-    period = math.floor( duration / step )
+    period = get_number_of_txn(begin_date, duration, step, max_txn=config['max_new_tx'])
 
     if(period > config['max_new_tx']):
         period = config['max_new_tx']
@@ -111,18 +129,18 @@ def distribute_over_period(params, default_date, total_value, config):
 
     dates = []
     amounts = []
-    date = begin_date
     accumulated_remainder = D(str(0))
 
-    while date < begin_date + datetime.timedelta(days=duration) and date <= datetime.date.today():
+    i = 0
+    while begin_date + i * step < begin_date + duration and begin_date + i * step <= datetime.date.today():
         accumulated_remainder += total_value / period
         if(abs(round_to(accumulated_remainder)) >= abs(round_to(config['min_value']))):
             amount = D(str(round_to(accumulated_remainder)))
             accumulated_remainder -= amount
             amounts.append(amount)
-            dates.append(date)
-        date = date + datetime.timedelta(days=step)
-        if(date > datetime.date.today()):
+            dates.append(begin_date + i * step)
+        i += 1
+        if(begin_date + i * step > datetime.date.today()):
             break
 
     return (dates, amounts)
@@ -144,13 +162,13 @@ def parse_length(int_or_string):
 
     try:
         dictionary = {
-            'day': 1,
-            'week': 7,
-            'month': 30,  # TODO.
-            'year': 365,  # TODO.
-            'inf': 365*1000000,
-            'infinite': 365*1000000,
-            'max': 365*1000000
+            'day': relativedelta(days=+1),
+            'week': relativedelta(weeks=+1),
+            'month': relativedelta(months=+1),  # TODO.
+            'year': relativedelta(years=+1),  # TODO.
+            'inf': relativedelta(days=+(365000000)),
+            'infinite': relativedelta(days=+(365000000)),
+            'max': relativedelta(days=+(365000000))
         }
         return dictionary[int_or_string.lower()]
     except:

--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -33,8 +33,8 @@ def get_number_of_txn(begin_date, duration, step):
 
     Note: This implementation requires 'step' to contain unique units which means either one of 'years', 'months' or
     'days'. Something like e.g. 'months=2, days=3' is not supported and might lead to wrong results.
-    """    
-    
+    """
+
     end_date = begin_date + duration
     diff = relativedelta(end_date, begin_date)
     if step.years:
@@ -144,16 +144,18 @@ def distribute_over_period(params, default_date, total_value, config):
     accumulated_remainder = D(str(0))
 
     i = 0
-    while begin_date + i * step < begin_date + duration and begin_date + i * step <= datetime.date.today():
+    end_date = begin_date + duration
+    today_date = datetime.date.today()
+    tmp_date = begin_date + i * step
+    while tmp_date < end_date and tmp_date <= today_date:
         accumulated_remainder += total_value / period
         if(abs(round_to(accumulated_remainder)) >= abs(round_to(config['min_value']))):
             amount = D(str(round_to(accumulated_remainder)))
             accumulated_remainder -= amount
             amounts.append(amount)
-            dates.append(begin_date + i * step)
+            dates.append(tmp_date)
         i += 1
-        if(begin_date + i * step > datetime.date.today()):
-            break
+        tmp_date = begin_date + i * step
 
     return (dates, amounts)
 

--- a/beancount_interpolate/recur.py
+++ b/beancount_interpolate/recur.py
@@ -1,8 +1,6 @@
 __author__ = 'Akuukis <akuukis@kalvis.lv>'
 import datetime
-import math
 
-from beancount.core.amount import Amount
 from beancount.core.data import filter_txns
 from beancount.core.number import D
 
@@ -10,13 +8,14 @@ from .common import extract_mark_tx
 from .common import new_whole_entries
 from .common import read_config
 from .common import parse_mark
+from .common import get_number_of_txn
 
 __plugins__ = ['recur']
 
 
 def dublicate_over_period(params, default_date, value, config):
     begin_date, duration, step = parse_mark(params, default_date, config)
-    period = math.floor( duration / step )
+    period = get_number_of_txn(begin_date, duration, step, config['max_new_tx'])
 
     if(period > config['max_new_tx']):
         period = config['max_new_tx']
@@ -24,11 +23,11 @@ def dublicate_over_period(params, default_date, value, config):
 
     dates = []
     amounts = []
-    date = begin_date
-    while date < begin_date + datetime.timedelta(days=duration) and date <= datetime.date.today():
-        amounts.append( D(str(value)) )
-        dates.append(date)
-        date = date + datetime.timedelta(days=step)
+    i = 0
+    while begin_date + i * step < begin_date + duration and begin_date + i * step <= datetime.date.today():
+        amounts.append(D(str(value)))
+        dates.append(begin_date + i * step)
+        i += 1
 
     return (dates, amounts)
 

--- a/beancount_interpolate/recur.py
+++ b/beancount_interpolate/recur.py
@@ -15,7 +15,7 @@ __plugins__ = ['recur']
 
 def dublicate_over_period(params, default_date, value, config):
     begin_date, duration, step = parse_mark(params, default_date, config)
-    period = get_number_of_txn(begin_date, duration, step, config['max_new_tx'])
+    period = get_number_of_txn(begin_date, duration, step)
 
     if(period > config['max_new_tx']):
         period = config['max_new_tx']


### PR DESCRIPTION
This PR fixes some problems with durations and step sizes being specified as number of days. This leads to problems in leap year or months with different number of days e.g.

This implementation improves on this by utilizing `dateutil.relativedelta.relativedelta`, which handles such corner cases nicely. Additionally the maximum value for `max`, `inf` and `infinite` for the duration value is getting set by using `datetime.MAXYEAR`. This was necessary as adding `relativedelta` objects can lead to `OverflowError`.