### PR TITLE
perf: `dublicate_over_period` as fast as before

### DIFF
--- a/beancount_interpolate/recur.py
+++ b/beancount_interpolate/recur.py
@@ -24,10 +24,14 @@ def duplicate_over_period(params, default_date, value, config):
     dates = []
     amounts = []
     i = 0
-    while begin_date + i * step < begin_date + duration and begin_date + i * step <= datetime.date.today():
+    end_date = begin_date + duration
+    today_date = datetime.date.today()
+    tmp_date = begin_date + i * step
+    while tmp_date < end_date and tmp_date <= today_date:
         amounts.append(D(str(value)))
-        dates.append(begin_date + i * step)
+        dates.append(tmp_date)
         i += 1
+        tmp_date = begin_date + i * step
 
     return (dates, amounts)
 

--- a/beancount_interpolate/recur.py
+++ b/beancount_interpolate/recur.py
@@ -13,7 +13,7 @@ from .common import get_number_of_txn
 __plugins__ = ['recur']
 
 
-def dublicate_over_period(params, default_date, value, config):
+def duplicate_over_period(params, default_date, value, config):
     begin_date, duration, step = parse_mark(params, default_date, config)
     period = get_number_of_txn(begin_date, duration, step)
 
@@ -34,7 +34,7 @@ def dublicate_over_period(params, default_date, value, config):
 
 def recur(entries, options_map, config_string=""):
     """
-    Beancount plugin: Dublicates all entry postings over time.
+    Beancount plugin: Duplicates all entry postings over time.
 
     Args:
       entries: A list of directives. We're interested only in the Transaction instances.
@@ -84,7 +84,7 @@ def recur(entries, options_map, config_string=""):
                     tags=tx.tags.difference([alias]),
                 )
 
-        newEntries = newEntries + new_whole_entries(tx, params, dublicate_over_period, config)
+        newEntries = newEntries + new_whole_entries(tx, params, duplicate_over_period, config)
 
     for trash in trashbin:
         entries.remove(trash)


### PR DESCRIPTION
Hi @Akuukis,

we actually forgot in #19 to apply the performance fix to the `dublicate_over_period` method in `recur.py`.
Alongside that I renamed the function to `duplicate_over_period`.