### PR TITLE
feat: flexible length specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,14 @@ Second, plugin inserts 30 or 31 transactions from 2016-05-01 to 2016-05-31 like 
 
 ### Notes
 
-The content of meta tag consists of 3 parts, every of them optional:
-1. numeric amount or a period - case-insensitive keyword "day", "week", "month" or "year". Defaults to "1".
-1. start date, prefixed with `@` sign. Defaults to transaction date.
-1. step size, prefixed with `/` sign. Can be either keyword from as period. Defaults to "day".
+The content of meta tag consists of 5 parts, every of them optional:
+1. amount `x`, a whole number. Defaults to 1.
+2. `period`, a case-insensitive keyword "day[s]", "week[s]", "month[s]" or "year[s]". Defaults to "day".
+3. start date, prefixed with `@` sign. Defaults to transaction date.
+4. step multiplier `m`, a whole number. Defaults to 1.
+5. `step` size, can be either keyword from as period. Defaults to "day".
 
-Summary: `[x|period] [@ YYYY-MM[-DD]] [/ step]`
+Summary: `[x] [period] [@ YYYY-MM[-DD]] [/ [m] [step]]`
 
 
 Details: Recur

--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -86,7 +86,8 @@ def parse_mark(mark, default_date, config):
     try:
         parts = re.findall(RE_PARSING, mark)[0]
         if parts[1] and parts[2]:
-            begin_date = datetime.date(int(parts[1]), int(parts[2]), int(parts[3]) or 1)
+            day = int(parts[3]) if parts[3] != '' else 1
+            begin_date = datetime.date(int(parts[1]), int(parts[2]), day)
         else:
             begin_date = default_date
 

--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -137,11 +137,11 @@ RE_PARSING = re.compile((
     r"^\s*([0-9]+(?=[\sa-zA-Z]+)(?!\s*[@$/]))?"
 
     # Match 'period' to be anything except '-', '/' or whitespace.
-    r"\s*?([^-/\s]+)?"
+    r"\s*([^-/\s]+)?"
 
     # Look for an @ and the following start date specification.
     # Specifying the date is optional.
-    r"\s*(?:@\s*?([0-9]{4})-([0-9]{2})(?:-([0-9]{2}))?)?"
+    r"\s*(?:@\s*([0-9]{4})-([0-9]{2})(?:-([0-9]{2}))?)?"
 
     # Look for an '/' which might be followed by a step size multiplicator
     # and step size.

--- a/tests/split/split.feature
+++ b/tests/split/split.feature
@@ -94,3 +94,32 @@ Feature: Split a transaction over a period
             2016-06-30 * "Me" "Set aside money for savings (split 30/30)" #split-month #splitted
                 Assets:MyBank:Savings              2.0 EUR
                 Assets:MyBank:Chequing            -2.0 EUR
+
+    Scenario: Split without losing cents
+        When this transaction is processed by split:
+            2016-06-01 * "Me" "Lost some pennies somewhere" #split-17
+                Assets:MyBank:Savings             0.27 EUR
+                Assets:MyBank:Chequing           -0.27 EUR
+
+        Then should not error
+        Then there should be total of 5 transactions
+        Then the transactions should include:
+            2016-06-03 * "Me" "Lost some pennies somewhere (split 1/5)" #split-17 #splitted
+                Assets:MyBank:Savings    0.05 EUR
+                Assets:MyBank:Chequing  -0.05 EUR
+
+            2016-06-06 * "Me" "Lost some pennies somewhere (split 2/5)" #split-17 #splitted
+                Assets:MyBank:Savings    0.05 EUR
+                Assets:MyBank:Chequing  -0.05 EUR
+
+            2016-06-10 * "Me" "Lost some pennies somewhere (split 3/5)" #split-17 #splitted
+                Assets:MyBank:Savings    0.06 EUR
+                Assets:MyBank:Chequing  -0.06 EUR
+
+            2016-06-13 * "Me" "Lost some pennies somewhere (split 4/5)" #split-17 #splitted
+                Assets:MyBank:Savings    0.05 EUR
+                Assets:MyBank:Chequing  -0.05 EUR
+
+            2016-06-17 * "Me" "Lost some pennies somewhere (split 5/5)" #split-17 #splitted
+                Assets:MyBank:Savings    0.06 EUR
+                Assets:MyBank:Chequing  -0.06 EUR

--- a/tests/spread/spread.feature
+++ b/tests/spread/spread.feature
@@ -94,3 +94,61 @@ Feature: Spread income or expense postings over a period
             2016-06-17 * "The Company" "Internet bill for June (spread 3/3)" #spreaded
                 Assets:Current:Bills:Internet                   25.0 EUR
                 Expenses:Bills:Internet                        -25.0 EUR
+
+    Scenario: Spread utility bill expenses over 3 days with period
+        Given this setup:
+            2010-01-01 open Expenses:Bills:Internet
+            2010-01-01 open Assets:MyBank:Checking
+            2010-01-01 open Assets:Current:Bills:Internet
+
+        When this transaction is processed by spread:
+            2016-06-15 * "The Company" "Internet bill for June"
+                Expenses:Bills:Internet                        -75.00 EUR
+                    spreadAfter: "3 day @ 2016-06-15"
+                Assets:MyBank:Checking                          75.00 EUR
+
+        Then should not error
+        Then there should be total of 4 transactions
+        Then that transaction should be modified:
+            2016-06-15 * "The Company" "Internet bill for June"
+                Assets:Current:Bills:Internet                  -75.00 EUR
+                Assets:MyBank:Checking                          75.00 EUR
+        Then the transactions should include:
+            2016-06-15 * "The Company" "Internet bill for June (spread 1/3)" #spreaded
+                Assets:Current:Bills:Internet                   25.0 EUR
+                Expenses:Bills:Internet                        -25.0 EUR
+            2016-06-16 * "The Company" "Internet bill for June (spread 2/3)" #spreaded
+                Assets:Current:Bills:Internet                   25.0 EUR
+                Expenses:Bills:Internet                        -25.0 EUR
+            2016-06-17 * "The Company" "Internet bill for June (spread 3/3)" #spreaded
+                Assets:Current:Bills:Internet                   25.0 EUR
+                Expenses:Bills:Internet                        -25.0 EUR
+
+    Scenario: Spread utility bill expenses over 6 weeks bi-weekly
+        Given this setup:
+            2010-01-01 open Expenses:Bills:Internet
+            2010-01-01 open Assets:MyBank:Checking
+            2010-01-01 open Assets:Current:Bills:Internet
+
+        When this transaction is processed by spread:
+            2016-06-15 * "The Company" "Internet bill for June"
+                Expenses:Bills:Internet                        -75.00 EUR
+                    spreadAfter: "6 weeks @ 2016-06-15 / 2 weeks"
+                Assets:MyBank:Checking                          75.00 EUR
+
+        Then should not error
+        Then there should be total of 4 transactions
+        Then that transaction should be modified:
+            2016-06-15 * "The Company" "Internet bill for June"
+                Assets:Current:Bills:Internet                  -75.00 EUR
+                Assets:MyBank:Checking                          75.00 EUR
+        Then the transactions should include:
+            2016-06-15 * "The Company" "Internet bill for June (spread 1/3)" #spreaded
+                Assets:Current:Bills:Internet                   25.0 EUR
+                Expenses:Bills:Internet                        -25.0 EUR
+            2016-06-29 * "The Company" "Internet bill for June (spread 2/3)" #spreaded
+                Assets:Current:Bills:Internet                   25.0 EUR
+                Expenses:Bills:Internet                        -25.0 EUR
+            2016-07-13 * "The Company" "Internet bill for June (spread 3/3)" #spreaded
+                Assets:Current:Bills:Internet                   25.0 EUR
+                Expenses:Bills:Internet                        -25.0 EUR


### PR DESCRIPTION
This PR implements more flexible lengths for periods and step sizes. With this, meta tags like the following are possible:

`[x] [period] [@ YYYY-MM[-DD]] [/ [m] [step]]`

See also the updated README.

Additionally I fixed an error when the start date has no day assigned. (1310bc7) And added some tests for the new feature. (9469c83)
To make the specification more fluid in terms of the language I also added the possibility to specify `days`, `weeks`, `months` and `years`.

Note for @Akuukis: After this PR I will have a look into the Bug #18.