### PR TITLE
fix: handle missing pennies for small amounts

### DIFF
--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -195,6 +195,13 @@ def distribute_over_period(params, default_date, total_value, config):
         i += 1
         tmp_date = begin_date + i * step
 
+    if sum(amounts) != total_value:
+        if len(amounts) == 0:
+            amounts.append(D(str(total_value)))
+            dates.append(begin_date)
+        else:
+            amounts[-1] += (total_value - sum(amounts))
+
     return (dates, amounts)
 
 

--- a/tests/split/split.feature
+++ b/tests/split/split.feature
@@ -123,3 +123,32 @@ Feature: Split a transaction over a period
             2016-06-17 * "Me" "Lost some pennies somewhere (split 5/5)" #split-17 #splitted
                 Assets:MyBank:Savings    0.06 EUR
                 Assets:MyBank:Chequing  -0.06 EUR
+
+    Scenario: Split small amount over month
+        When this transaction is processed by split:
+            2020-06-01 * "shop" "cookies" #split-month
+                Assets:MyBank:Chequing                           0.13 EUR
+                Assets:MyBank:Savings                           -0.13 EUR
+
+        Then should not error
+        Then there should be total of 2 transactions
+        Then the transactions should include:
+            2020-06-11 * "shop" "cookies (split 1/2)" #split-month #splitted
+                Assets:MyBank:Savings                           -0.05 EUR
+                Assets:MyBank:Chequing                           0.05 EUR
+            2020-06-22 * "shop" "cookies (split 2/2)" #split-month #splitted
+                Assets:MyBank:Savings                           -0.08 EUR
+                Assets:MyBank:Chequing                           0.08 EUR
+
+    Scenario: Split amount below min_value over month
+        When this transaction is processed by split:
+            2020-06-01 * "shop" "cookies" #split-month
+                Assets:MyBank:Chequing                           0.03 EUR
+                Assets:MyBank:Savings                           -0.03 EUR
+
+        Then should not error
+        Then there should be total of 1 transactions
+        Then the transactions should include:
+            2020-06-01 * "shop" "cookies (split 1/1)" #split-month #splitted
+                Assets:MyBank:Savings                           -0.03 EUR
+                Assets:MyBank:Chequing                           0.03 EUR

--- a/tests/spread/spread.feature
+++ b/tests/spread/spread.feature
@@ -152,3 +152,50 @@ Feature: Spread income or expense postings over a period
             2016-07-13 * "The Company" "Internet bill for June (spread 3/3)" #spreaded
                 Assets:Current:Bills:Internet                   25.0 EUR
                 Expenses:Bills:Internet                        -25.0 EUR
+
+    Scenario: Spread small amount over month
+        Given this setup:
+            2020-01-01 open Expenses:Random
+            2020-01-01 open Assets:Cash
+            2020-01-01 open Assets:Current:Random
+
+        When this transaction is processed by spread:
+            2020-06-01 * "shop" "cookies" #spread-month
+                Expenses:Random                                  0.13 EUR
+                Assets:Cash                                     -0.13 EUR
+
+        Then should not error
+        Then there should be total of 3 transactions
+        Then that transaction should be modified:
+            2020-06-01 * "shop" "cookies" #spread-month
+                Assets:Current:Random                            0.13 EUR
+                Assets:Cash                                     -0.13 EUR
+        Then the transactions should include:
+            2020-06-11 * "shop" "cookies (spread 1/2)" #spread-month #spreaded
+                Assets:Current:Random                           -0.05 EUR
+                Expenses:Random                                  0.05 EUR
+            2020-06-22 * "shop" "cookies (spread 2/2)" #spread-month #spreaded
+                Assets:Current:Random                           -0.08 EUR
+                Expenses:Random                                  0.08 EUR
+
+    Scenario: Spread amount below min_value over month
+        Given this setup:
+            2020-01-01 open Expenses:Random
+            2020-01-01 open Assets:Cash
+            2020-01-01 open Assets:Current:Random
+
+        When this transaction is processed by spread:
+            2020-06-01 * "shop" "cookies" #spread-month
+                Expenses:Random                                  0.03 EUR
+                Assets:Cash                                     -0.03 EUR
+
+        Then should not error
+        Then there should be total of 2 transactions
+        Then that transaction should be modified:
+            2020-06-01 * "shop" "cookies" #spread-month
+                Assets:Current:Random                            0.03 EUR
+                Assets:Cash                                     -0.03 EUR
+        Then the transactions should include:
+            2020-06-01 * "shop" "cookies (spread 1/1)" #spread-month #spreaded
+                Assets:Current:Random                           -0.03 EUR
+                Expenses:Random                                  0.03 EUR


### PR DESCRIPTION
Closes #18

If there are remainders they are now getting added to the last
transaction. If there is no last transaction because the total amount is
smaller than `min_value` there will be a transaction added at
`begin_date`.

Also added some tests covering the corner cases.