### PR TITLE
feat: add allow_future option to generate entries beyond today

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Options that applies to all four plugins:
 * `max_new_tx` - integer that will be the maximal amount of newly created transactions.
 * `suffix` - string appended to created transaction annotations. Two variables are n-th transaction and total amount of transactions.
 * `tag` - string that as tag will be applied to all created transactions.
+* `allow_future` - boolean, if true the plugin will generate entries for future dates. Defaults to false (entries are only generated up to today, with the remainder accumulated into the last entry).
 
 Options that applies only to `spread` and `depr`. For `spread` new transactions are created under account name where `account_expense` and `account_income` prefixes are swapped to `account_assets` or `account_liab` prefixes respectively. For `depr` that other way around: `account_assets` and `account_liab` prefixes are swapped to `account_expense` and `account_income` prefixes instead.
 * `account_income`
@@ -315,7 +316,8 @@ plugin "beancount_interpolate.recur" "{
     'min_value': 0.05,
     'max_new_tx': 9999,
     'suffix': ' (recur %d/%d)',
-    'tag': 'recurred'
+    'tag': 'recurred',
+    'allow_future': False
 }"
 
 plugin "beancount_interpolate.split" "{
@@ -326,7 +328,8 @@ plugin "beancount_interpolate.split" "{
     'min_value': 0.05,
     'max_new_tx': 9999,
     'suffix': ' (split %d/%d)',
-    'tag': 'splitted'
+    'tag': 'splitted',
+    'allow_future': False
 }"
 
 plugin "beancount_interpolate.spread" "{
@@ -341,7 +344,8 @@ plugin "beancount_interpolate.spread" "{
     'min_value': 0.05,  # cannot be smaller than 0.01
     'max_new_tx': 9999,
     'suffix': ' (spread %d/%d)',
-    'tag': 'spreaded'
+    'tag': 'spreaded',
+    'allow_future': False
 }"
 
 plugin "beancount_interpolate.depr" "{
@@ -355,7 +359,8 @@ plugin "beancount_interpolate.depr" "{
     'min_value': 0.05,  # cannot be smaller than 0.01
     'max_new_tx': 9999,
     'suffix': ' (depr %d/%d)',
-    'tag': 'depred'
+    'tag': 'depred',
+    'allow_future': False
 }"
 ```
 

--- a/beancount_interpolate/common.py
+++ b/beancount_interpolate/common.py
@@ -184,8 +184,9 @@ def distribute_over_period(params, default_date, total_value, config):
     i = 0
     end_date = begin_date + duration
     today_date = datetime.date.today()
+    allow_future = config.get('allow_future', False)
     tmp_date = begin_date + i * step
-    while tmp_date < end_date and tmp_date <= today_date:
+    while tmp_date < end_date and (allow_future or tmp_date <= today_date):
         accumulated_remainder += total_value / period
         if(abs(round_to(accumulated_remainder)) >= abs(round_to(config['min_value']))):
             amount = D(str(round_to(accumulated_remainder)))

--- a/beancount_interpolate/depreciate.py
+++ b/beancount_interpolate/depreciate.py
@@ -38,6 +38,7 @@ def depreciate(entries, options_map, config_string=""):
         'max_new_tx'      : config_obj.pop('max_new_tx'      , 9999),
         'suffix'          : config_obj.pop('suffix'          , ' (depr %d/%d)'),
         'tag'             : config_obj.pop('tag'             , 'depreciated'),
+        'allow_future'    : config_obj.pop('allow_future'    , False),
         'translations'    : {
             config_obj.pop('account_assets'  , 'Assets:Fixed')     : config_obj.pop('account_expenses', 'Expenses:Depreciation'),
             config_obj.pop('account_liab'    , 'Liabilities:Fixed'): config_obj.pop('account_income'  , 'Income:Appreciation'),

--- a/beancount_interpolate/recur.py
+++ b/beancount_interpolate/recur.py
@@ -26,8 +26,9 @@ def duplicate_over_period(params, default_date, value, config):
     i = 0
     end_date = begin_date + duration
     today_date = datetime.date.today()
+    allow_future = config.get('allow_future', False)
     tmp_date = begin_date + i * step
-    while tmp_date < end_date and tmp_date <= today_date:
+    while tmp_date < end_date and (allow_future or tmp_date <= today_date):
         amounts.append(D(str(value)))
         dates.append(tmp_date)
         i += 1
@@ -62,6 +63,7 @@ def recur(entries, options_map, config_string=""):
         'max_new_tx'      : config_obj.pop('max_new_tx'      , 9999),
         'suffix'          : config_obj.pop('suffix'          , ' (recur %d/%d)'),
         'tag'             : config_obj.pop('tag'             , 'recurred'),
+        'allow_future'    : config_obj.pop('allow_future'    , False),
     }
 
     newEntries = []

--- a/beancount_interpolate/split.py
+++ b/beancount_interpolate/split.py
@@ -38,6 +38,7 @@ def split(entries, options_map, config_string=""):
         'max_new_tx'      : config_obj.pop('max_new_tx'      , 9999),
         'suffix'          : config_obj.pop('suffix'          , ' (split %d/%d)'),
         'tag'             : config_obj.pop('tag'             , 'splitted'),
+        'allow_future'    : config_obj.pop('allow_future'    , False),
     }
 
     newEntries = []

--- a/beancount_interpolate/spread.py
+++ b/beancount_interpolate/spread.py
@@ -43,6 +43,7 @@ def spread(entries, options_map, config_string=""):
         'max_new_tx'      : config_obj.pop('max_new_tx'      , 9999),
         'suffix'          : config_obj.pop('suffix'          , ' (spread %d/%d)'),
         'tag'             : config_obj.pop('tag'             , 'spreaded'),
+        'allow_future'    : config_obj.pop('allow_future'    , False),
         'translations'    : {
             config_obj.pop('account_expenses', 'Expenses'): config_obj.pop('account_assets'  , 'Assets:Current'),
             config_obj.pop('account_income'  , 'Income')  : config_obj.pop('account_liab'    , 'Liabilities:Current'),

--- a/tests/spread/spread.feature
+++ b/tests/spread/spread.feature
@@ -178,6 +178,37 @@ Feature: Spread income or expense postings over a period
                 Assets:Current:Random                           -0.08 EUR
                 Expenses:Random                                  0.08 EUR
 
+    Scenario: Spread expenses over future days with allow_future
+        Given this config:
+            {'allow_future': True}
+        Given this setup:
+            2010-01-01 open Expenses:Bills:Internet
+            2010-01-01 open Assets:MyBank:Checking
+            2010-01-01 open Assets:Current:Bills:Internet
+
+        When this transaction is processed by spread:
+            2099-06-15 * "The Company" "Internet bill for June"
+                Expenses:Bills:Internet                        -75.00 EUR
+                    spreadAfter: "3 @ 2099-06-15"
+                Assets:MyBank:Checking                          75.00 EUR
+
+        Then should not error
+        Then there should be total of 4 transactions
+        Then that transaction should be modified:
+            2099-06-15 * "The Company" "Internet bill for June"
+                Assets:Current:Bills:Internet                  -75.00 EUR
+                Assets:MyBank:Checking                          75.00 EUR
+        Then the transactions should include:
+            2099-06-15 * "The Company" "Internet bill for June (spread 1/3)" #spreaded
+                Assets:Current:Bills:Internet                   25.0 EUR
+                Expenses:Bills:Internet                        -25.0 EUR
+            2099-06-16 * "The Company" "Internet bill for June (spread 2/3)" #spreaded
+                Assets:Current:Bills:Internet                   25.0 EUR
+                Expenses:Bills:Internet                        -25.0 EUR
+            2099-06-17 * "The Company" "Internet bill for June (spread 3/3)" #spreaded
+                Assets:Current:Bills:Internet                   25.0 EUR
+                Expenses:Bills:Internet                        -25.0 EUR
+
     Scenario: Spread amount below min_value over month
         Given this setup:
             2020-01-01 open Expenses:Random


### PR DESCRIPTION
Hi Akuukis,

Thanks for the very useful plugin! I wanted to submit a PR to add a possibly-useful feature:  An `allow_future` config option (default: False) that allows entries to be generated for the full period specified, including future dates.

### Motivation

Right now, the plugin  refuses to generate entries for future time periods and dumps any remainder into the last time period. That can be problematic if, for example, your income is "lumpy" (e.g., due to bonuses, or uneven partnership draws, the Dutch phenomenon of "holiday pay", etc.) and you want to smooth it across a given time period.

For example, say your January income is outsized compared to other months. Right now, when you ask the plugin to spread it evenly across 12 months using `spread: "Year @ 2026-01-01 / Month"`, the plugin refuses to generate entries for future months and dumps the entire remainder into the most recent month (currently February). So right now, that means 11/12 of the annual amount gets assigned to February.

The allow_future option lets users opt into generating future-dated entries when that's the desired behavior, while preserving the existing default for use cases like recur where stopping at today makes sense.

### Behavior

  - When True, entries are generated for the full specified period regardless of today's date
  - When False (default), existing behavior is preserved — entries stop at today and the remainder is accumulated into the last entry

### Tests and README

  - Added a new BDD test scenario (Spread expenses over future days with allow_future) that verifies entries are correctly generated for a far-future date (2099) when allow_future is True
  - All  existing tests continue to pass
  - Updated the README with a description of the option and added it to the examples therein

